### PR TITLE
Updating branch of rosbridge_suite to 'develop' vs missing 'hydro-devel'

### DIFF
--- a/rocon.rosinstall
+++ b/rocon.rosinstall
@@ -19,7 +19,7 @@
 {'git': {'local-name': 'std_capabilities', 'version': 'initial_specs', 'uri': 'https://github.com/robotics-in-concert/std_capabilities.git'}},
 {'git': {'local-name': 'rqt_capabilities', 'version': 'master', 'uri': 'https://github.com/robotics-in-concert/rqt_capabilities.git'}},
 
-{'git': {'local-name': 'rosbridge_suite', 'version': 'hydro-devel', 'uri': 'https://github.com/RobotWebTools/rosbridge_suite.git'}},
+{'git': {'local-name': 'rosbridge_suite', 'version': 'develop', 'uri': 'https://github.com/RobotWebTools/rosbridge_suite.git'}},
 
 # Experimental
 {'git': {'local-name': 'rocon_rapps', 'version': 'indigo', 'uri': 'https://github.com/robotics-in-concert/rocon_rapps.git'}},


### PR DESCRIPTION
Hello!  Per this email:

http://lists.ros.org/pipermail/ros-users/2014-July/068820.html

There is no 'hydro-devel' branch in the rosbridge_suite repo so this is breaking when compiling from source in indigo.  Here is a small change to use the 'develop' branch instead, which allows the installation of rocon from source to succeed.

Thanks, Dylan
