### PR TITLE
Point rocon_qt_gui to newest kinetic patch

### DIFF
--- a/rocon.rosinstall
+++ b/rocon.rosinstall
@@ -7,7 +7,7 @@
 {'git': {'local-name': 'rocon_msgs',            'version': 'release/0.9-kinetic', 'uri': 'https://github.com/robotics-in-concert/rocon_msgs.git'         }},
 {'git': {'local-name': 'rocon_tools',           'version': 'release/0.3-kinetic', 'uri':'https://github.com/robotics-in-concert/rocon_tools.git'         }},
 {'git': {'local-name': 'rocon_app_platform',    'version': 'release/0.8-kinetic', 'uri': 'https://github.com/robotics-in-concert/rocon_app_platform.git' }},
-{'git': {'local-name': 'rocon_qt_gui',          'version': 'release/0.9-kinetic', 'uri': 'https://github.com/robotics-in-concert/rocon_qt_gui.git'       }},
+{'git': {'local-name': 'rocon_qt_gui',          'version': 'kinetic-devel', 'uri': 'https://github.com/robotics-in-concert/rocon_qt_gui.git'       }},
 
 # Need to deprecate the concert tutorials here
 # {'git': {'local-name': 'rocon_tutorials',       'version': 'release/0.6-kinetic', 'uri': 'https://github.com/robotics-in-concert/rocon_tutorials.git'    }},


### PR DESCRIPTION
This patch points rocon_qt_gui to the `kinetic-devel` branch so as to include commits related to Qt5 support: https://github.com/robotics-in-concert/rocon_qt_gui/commit/d774fef748be43fb77fdcab7264f2ac833bae4c2